### PR TITLE
feat/after-edit-calendar-activity-redirect-to-activities-list

### DIFF
--- a/app/controllers/responsible/activities_controller.rb
+++ b/app/controllers/responsible/activities_controller.rb
@@ -39,7 +39,7 @@ class Responsible::ActivitiesController < Responsible::BaseController
   def update
     if @activity.update(activity_params)
       feminine_success_update_message
-      redirect_to responsible_calendar_activity_path(@calendar, @activity)
+      redirect_to responsible_calendar_activities_path
     else
       error_message
       render :edit

--- a/app/controllers/responsible/activities_controller.rb
+++ b/app/controllers/responsible/activities_controller.rb
@@ -29,7 +29,7 @@ class Responsible::ActivitiesController < Responsible::BaseController
 
     if @activity.save
       feminine_success_create_message
-      redirect_to responsible_calendar_activities_path
+      redirect_to responsible_calendar_activities_path(@calendar)
     else
       error_message
       render :new
@@ -39,7 +39,7 @@ class Responsible::ActivitiesController < Responsible::BaseController
   def update
     if @activity.update(activity_params)
       feminine_success_update_message
-      redirect_to responsible_calendar_activities_path
+      redirect_to responsible_calendar_activities_path(@calendar)
     else
       error_message
       render :edit

--- a/spec/features/responsible/activities/activities_update_spec.rb
+++ b/spec/features/responsible/activities/activities_update_spec.rb
@@ -21,9 +21,10 @@ describe 'Activity::update', type: :feature, js: true do
         selectize(attributes[:base_activity_type].name, from: 'activity_base_activity_type_id')
         submit_form('input[name="commit"]')
 
-        expect(page).to have_current_path responsible_calendar_activities_path(activity.calendar)
+        current_path = responsible_calendar_activities_path(activity.calendar)
+        expect(page).to have_current_path current_path
         expect(page).to have_flash(:success, text: message('update.f'))
-        expect(page).to have_message(attributes[:name], in: 'table tbody')                               
+        expect(page).to have_message(attributes[:name], in: 'table tbody')
       end
     end
 

--- a/spec/features/responsible/activities/activities_update_spec.rb
+++ b/spec/features/responsible/activities/activities_update_spec.rb
@@ -21,11 +21,9 @@ describe 'Activity::update', type: :feature, js: true do
         selectize(attributes[:base_activity_type].name, from: 'activity_base_activity_type_id')
         submit_form('input[name="commit"]')
 
-        current_path = responsible_calendar_activity_path(activity.calendar, activity)
-        expect(page).to have_current_path current_path
+        expect(page).to have_current_path responsible_calendar_activities_path(activity.calendar)
         expect(page).to have_flash(:success, text: message('update.f'))
-        expect(page).to have_contents([attributes[:name],
-                                       attributes[:base_activity_type].name])
+        expect(page).to have_message(attributes[:name], in: 'table tbody')                               
       end
     end
 


### PR DESCRIPTION
## PR Template

After update a activity calendar redirect to activities list

https://github.com/users/MarczalTSIGP/projects/1/views/1?pane=issue&itemId=35651867

Issue: #**202**

### Description

In responsible activitiesController was edit the redirect for activity show page to activities list

### Motivation and Context

For System Standard

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?

Test in the browser: 
access as professor > update activity > see the redirect page  

Test by system:
`docker compose exec tests bundle exec rspec spec/features/responsible/activities`

### Screenshots (if appropriate):

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] fix: A bug fix
- [x] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [x] test: Adding missing tests or correcting existing tests
- [ ] perf: A code change that improves performance
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (e.g. prettier format)
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Changes to the build process or auxiliary tools and librariesfunctionality to not work as expected)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Hours Required:
1 hour