### PR TITLE
Feat: Show and hide field o register of the activity, do like base ac…

### DIFF
--- a/app/views/responsible/activities/_form.html.erb
+++ b/app/views/responsible/activities/_form.html.erb
@@ -7,8 +7,12 @@
 
       <div class="col-md-6">
         <%= f.association :base_activity_type,
-          input_html: { data: 'selectize' },
-          prompt: t('prompt.select.m', name: 'tipo') %>
+        input_html: { 
+                                  class: 'activity_type_hide_event',
+                                  data: 'selectize',
+                                  "base-activities-types" => BaseActivityType.all.to_h { |b| [b.id, b.identifier] }.to_json
+                              },
+                              prompt: t('prompt.select.m', name: 'tipo') %>
       </div>
     </div>
 
@@ -30,21 +34,22 @@
           datetime="<%= @activity.final_date %>" />
       </div>
     </div>
+    <div hide-on-activity-type-info-selected>
+      <% if @calendar.tcc == 'one' %>
+        <%= f.input :identifier,
+          as: :radio_button_tabler,
+          collection: Activity.human_tcc_one_identifiers %>
+      <% else %>
+        <%= f.input :identifier, as: :hidden, input_html: { value: :monograph } %>
+      <% end %>
 
-    <% if @calendar.tcc == 'one' %>
-      <%= f.input :identifier,
-        as: :radio_button_tabler,
-        collection: Activity.human_tcc_one_identifiers %>
-    <% else %>
-      <%= f.input :identifier, as: :hidden, input_html: { value: :monograph } %>
-    <% end %>
+      <%= f.input :judgment, as: :checkbox_tabler %>
+      <%= f.input :final_version, as: :checkbox_tabler %>
 
-    <%= f.input :judgment, as: :checkbox_tabler %>
-    <%= f.input :final_version, as: :checkbox_tabler %>
-
-    <%= f.input :tcc,
-      as: :hidden,
-      input_html: { value: @calendar.tcc } %>
+      <%= f.input :tcc,
+        as: :hidden,
+        input_html: { value: @calendar.tcc } %>
+      </div>
 </div>
 
 <div class="d-flex">

--- a/spec/features/responsible/activities/activities_create_spec.rb
+++ b/spec/features/responsible/activities/activities_create_spec.rb
@@ -19,6 +19,10 @@ describe 'Activity::create', type: :feature, js: true do
         click_on_label(Activity.human_tcc_one_identifiers.first[0], in: 'activity_identifier')
         selectize(base_activity_types.first.name, from: 'activity_base_activity_type_id')
 
+        expect(page).not_to have_field('activity_identifier')
+        expect(page).not_to have_field('activity_judgment')
+        expect(page).not_to have_field('activity_final_version')
+
         submit_form('input[name="commit"]')
         expect(page).to have_current_path responsible_calendar_activities_path(calendar)
         expect(page).to have_flash(:success, text: message('create.f'))


### PR DESCRIPTION
…tivity

## PR Template

[<!--- Provide a general summary of your changes in the Title above. -->](https://github.com/users/MarczalTSIGP/projects/1?pane=issue&itemId=41543608)

<!-- Autolinked issue URL -->

Issue: #267 

### Description

Fazer aparecer e sumir o campo de tipo de documentos de atividades assim como já acontece em base activities.

### Motivation and Context

Atualmente ao criar uma atividade base os campos de tipo de documentos são ocultados caso o tipo de atividade seja informativa, mas o mesmo não acontece ao criar uma nova atividade. 

### How has this been tested?

Foi testado utilizando a página, alterando o select e adicionado a verificação se os campos somem em teste.

### Screenshots (if appropriate):

Como era antigamente:
![image](https://github.com/MarczalTSIGP/SGTCC/assets/91571777/9aa4d0a3-11a6-45ab-a1eb-6a85a057d718)

Hoje:
TCC1:

![image](https://github.com/MarczalTSIGP/SGTCC/assets/91571777/3291c964-abac-4496-9c87-521105c3adc8)
![image](https://github.com/MarczalTSIGP/SGTCC/assets/91571777/d2a367c7-1b3d-4927-9a08-e9496511202e)

TCC2:

![image](https://github.com/MarczalTSIGP/SGTCC/assets/91571777/b8547c9b-46f9-43f3-8bcf-989dadf1ad83)
![image](https://github.com/MarczalTSIGP/SGTCC/assets/91571777/c1858bbe-4625-47ea-859e-c84f3c5ed1ae)

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] fix: A bug fix
- [x] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] test: Adding missing tests or correcting existing tests
- [ ] perf: A code change that improves performance
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (e.g. prettier format)
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Changes to the build process or auxiliary tools and librariesfunctionality to not work as expected)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Hours Required:
