### PR TITLE
Fixed orientation current_calendar to return correctly calendar

### DIFF
--- a/app/models/orientation.rb
+++ b/app/models/orientation.rb
@@ -117,9 +117,8 @@ class Orientation < ApplicationRecord
 
   def current_calendar
     calendars.order(
-      { year: :desc },
-      { semester: :desc }
-    ).first
+      year: :asc, semester: :asc, tcc: :asc
+    ).last
   end
 
   # TODO: Refactored and Remove

--- a/app/uploaders/appointment_file_uploader.rb
+++ b/app/uploaders/appointment_file_uploader.rb
@@ -27,7 +27,7 @@ class AppointmentFileUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
+  def extension_allowlist
     %w[zip rar pdf doc docx xls xlsx ods odt odp txt]
   end
 

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -27,7 +27,7 @@ class FileUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
+  def extension_allowlist
     %w[zip rar pdf doc docx xls xlsx ods odt odp]
   end
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -27,7 +27,7 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
+  def extension_allowlist
     %w[jpg jpeg gif png]
   end
 

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -27,7 +27,7 @@ class PdfUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
+  def extension_allowlist
     %w[pdf]
   end
 

--- a/app/uploaders/profile_image_uploader.rb
+++ b/app/uploaders/profile_image_uploader.rb
@@ -33,7 +33,7 @@ class ProfileImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
+  def extension_allowlist
     %w[jpg jpeg gif png]
   end
 

--- a/app/uploaders/zip_uploader.rb
+++ b/app/uploaders/zip_uploader.rb
@@ -27,7 +27,7 @@ class ZipUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
+  def extension_allowlist
     %w[zip]
   end
 

--- a/app/views/professors/documents/_document_review.html.erb
+++ b/app/views/professors/documents/_document_review.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td>
     <span data-toggle="tooltip" title="<%= document.orientation.title %>">
-      <%= document.orientation.short_title %>
+      <%= link_to document.orientation.short_title, professors_document_path(document) %>
     </span>
   </td>
   <td><%= document.orientation.academic.name %></td>

--- a/spec/features/responsible/documents/documents_review_spec.rb
+++ b/spec/features/responsible/documents/documents_review_spec.rb
@@ -10,6 +10,26 @@ describe 'Document::review', :js, type: :feature do
     login_as(responsible, scope: :professor)
   end
 
+  describe '#index' do
+    let(:tep) { create(:document_tep, orientation_id: orientation.id) }
+
+    before do
+      signatures = tep.signatures.reject { |s| s.user_type.eql?('professor_responsible') }
+      signatures.each(&:sign)
+      visit professors_documents_reviewing_path
+    end
+
+    it 'shows the pending documents' do
+      within('table tbody') do
+        expect(page).to have_link(text: orientation.short_title,
+                                  href: professors_document_path(tep))
+        expect(page).to have_content(orientation.academic.name)
+        expect(page).to have_content(tep.document_type.identifier.upcase)
+        expect(page).to have_content(short_date(document.created_at))
+      end
+    end
+  end
+
   describe '#create' do
     before do
       visit professors_document_path(document)

--- a/spec/models/orientations/orientation_current_calendar_spec.rb
+++ b/spec/models/orientations/orientation_current_calendar_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Orientation, type: :model do
+  describe '#current_calendar' do
+    it 'returns the tcc two calendar' do
+      calendar_one = create(:previous_calendar_tcc_one)
+      calendar_two = create(:current_calendar_tcc_two)
+
+      orientation = create(:orientation, calendar_ids: [calendar_two.id, calendar_one.id])
+
+      expect(orientation.current_calendar).to eq(calendar_two)
+    end
+
+    it 'returns the tcc two calendar when two calendars in same semester' do
+      calendar_one = create(:current_calendar_tcc_one)
+      calendar_two = create(:current_calendar_tcc_two)
+
+      orientation = create(:orientation, calendar_ids: [calendar_two.id, calendar_one.id])
+
+      expect(orientation.current_calendar).to eq(calendar_two)
+    end
+  end
+end


### PR DESCRIPTION
## PR Template

<!--- Provide a general summary of your changes in the Title above. -->

<!-- Autolinked issue URL -->

Issue: **#288**

### Description

<!--- Describe your changes in detail -->

### Motivation and Context

The current calendar may not return the last calendar when the `created_at` differ from chronological sequence of created, so need to order by year, semester and TCC.

 It was missing the link to responsible access a document to judgment.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] fix: A bug fix
- [ ] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [x] test: Adding missing tests or correcting existing tests
- [ ] perf: A code change that improves performance
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (e.g. prettier format)
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Changes to the build process or auxiliary tools and libraries functionality to not work as expected)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Hours Required: 0.5
