### PR TITLE
Fixed bug in generate TCO after create an orientation

### DIFF
--- a/app/models/concerns/orientation_tco_tcai.rb
+++ b/app/models/concerns/orientation_tco_tcai.rb
@@ -4,7 +4,7 @@ module OrientationTcoTcai
   extend ActiveSupport::Concern
 
   included do
-    after_create :create_tco_and_tcai
+    after_create_commit :create_tco_and_tcai
     after_update :recreate_tco_and_tcai
 
     def create_tco(params)

--- a/app/views/site/orientations/_card.html.erb
+++ b/app/views/site/orientations/_card.html.erb
@@ -4,7 +4,7 @@
 
 <% if tcc_two_orientations.present? %>
    <div id="tcc_two">
-      <%= render 'site/orientations/table', orientations: tcc_two_orientations %>
+      <%= render 'site/orientations/table', orientations: tcc_two_orientations, type: :orientations %>
    </div>
 <% end %>
 
@@ -14,6 +14,6 @@
 
 <% if tcc_two_supervisions.present? %>
    <div id="tcc_two">
-      <%= render 'site/orientations/table', orientations: tcc_two_supervisions %>
+      <%= render 'site/orientations/table', orientations: tcc_two_supervisions, type: :supervisions %>
    </div>
 <% end %>

--- a/app/views/site/orientations/_table.html.erb
+++ b/app/views/site/orientations/_table.html.erb
@@ -1,26 +1,26 @@
 <div class="text-right mt-3">
-  <%= I18n.t('site.pages.professors.orientations.total', count: orientations.size ) %>
+   <%= I18n.t("site.pages.professors.#{type}.total", count: orientations.size ) %>
 </div>
 
 <div class="site-table table-striped mt-3 table-responsive w-100">
-  <table class="border border-gray card-table table-vcenter text-nowrap">
-    <thead>
-      <tr>
-        <th><%= Orientation.human_attribute_name('academic') %></th>
-        <th><%= Orientation.human_attribute_name('title') %></th>
-        <th><%= Orientation.human_attribute_name('advisor') %></th>
-        <th><%= Orientation.human_attribute_name('orientation_supervisors') %></th>
-        <th><%= Orientation.human_attribute_name('documents') %></th>
-      </tr>
-    </thead>
+   <table class="border border-gray card-table table-vcenter text-nowrap">
+      <thead>
+         <tr>
+            <th><%= Orientation.human_attribute_name('academic') %></th>
+            <th><%= Orientation.human_attribute_name('title') %></th>
+            <th><%= Orientation.human_attribute_name('advisor') %></th>
+            <th><%= Orientation.human_attribute_name('orientation_supervisors') %></th>
+            <th><%= Orientation.human_attribute_name('documents') %></th>
+         </tr>
+      </thead>
 
-    <tbody>
-      <tr>
-        <%= render('shared/no_results') if orientations.empty? %>
-      </tr>
-      <% orientations.each do |orientation| %>
-        <%= render 'site/orientations/orientation', orientation: orientation %>
-      <% end %>
-    </tbody>
-  </table>
+      <tbody>
+         <tr>
+            <%= render('shared/no_results') if orientations.empty? %>
+         </tr>
+         <% orientations.each do |orientation| %>
+            <%= render 'site/orientations/orientation', orientation: orientation %>
+         <% end %>
+      </tbody>
+   </table>
 </div>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -143,6 +143,9 @@ pt-BR:
         supervisions:
           in_progress: 'Coorientações em andamento'
           approved: 'Coorientações concluídas'
+          total: 
+            one: 'Total de 1 coorientação'
+            other: 'Total de %{count} coorientações'
       examination_boards:
         defense: 'Bancas de TCC %{calendar}'
   breadcrumbs:

--- a/spec/models/orientations/orientation_after_create_spec.rb
+++ b/spec/models/orientations/orientation_after_create_spec.rb
@@ -2,11 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Orientation do
   describe '#after_create' do
-    let(:orientation) { create(:orientation) }
+    let(:orientation) { build(:orientation) }
     let(:signatures) { orientation.signatures }
 
     before do
-      orientation.signatures << Signature.all
+      create(:document_type_tco)
+      create(:document_type_tcai)
+
+      orientation.professor_supervisors << create(:professor)
+      orientation.external_member_supervisors << create(:external_member)
+
+      orientation.save!
     end
     # rubocop:disable RSpec/MultipleMemoizedHelpers
 


### PR DESCRIPTION
## Bug Fix in generate TCO after create an orientation

Issue: #**338**

### Description

When you have model relationship, you should use after_create_commit instead of after_create callback because just after commit, the relation will be effective to query consults.

### Types of changes

- [x] fix: A bug fix
- [ ] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] enhancement: An enhancement makes something better
- [ ] test: Adding missing tests or correcting existing tests
- [ ] perf: A code change that improves performance
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (e.g. prettier format)
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Changes to the build process or auxiliary tools and libraries functionality to not work as expected
