### PR TITLE
Fix Dockerfile to ensure wget and ca-certificates are installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update -qq && \
 RUN apt-get install -y lsb-release
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" >>  /etc/apt/sources.list.d/pgdg.list     &&  \
   sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-  apt-get install wget ca-certificates && \
+  apt-get install -y wget ca-certificates && \
   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
   apt-get update -qq && \
   apt-get install -y postgresql-client


### PR DESCRIPTION
## Fix Dockerfile to ensure wget and ca-certificates are installed

<!--- Provide a general summary of your changes in the Title above. -->

<!-- Autolinked issue URL -->

Issue: #

### Description

Added the `-y` flag to the package installation command in the Dockerfile for `wget` and `ca-certificates`.  

### Motivation and Context

This change was necessary because the Dockerfile build process was getting stuck, waiting for manual confirmation during package installation.  
Adding the `-y` flag makes the installation non-interactive, allowing the Docker build to proceed automatically without user input.

### How has this been tested?

The build completed successfully, confirming that the addition of the `-y` flag resolved the installation issue.

### Screenshots (if appropriate):

### Types of changes

- [x] fix: A bug fix
- [ ] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] enhancement: An enhancement makes something better
- [ ] test: Adding missing tests or correcting existing tests
- [ ] perf: A code change that improves performance
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (e.g. prettier format)
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Changes to the build process or auxiliary tools and libraries functionality to not work as expected

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Hours Required:
