### PR TITLE
Clear examination board cachee on academic activity save

### DIFF
--- a/app/models/academic_activity.rb
+++ b/app/models/academic_activity.rb
@@ -9,6 +9,8 @@ class AcademicActivity < ApplicationRecord
   validates :summary, presence: true
   validates :pdf, presence: true
 
+  after_commit :clear_examination_boards_cache
+
   def update_judgment
     update(judgment: true)
   end
@@ -25,5 +27,16 @@ class AcademicActivity < ApplicationRecord
 
   def complementary_files_filename
     "#{academic_filename}_AC_#{activity.identifier_translated}".upcase
+  end
+
+  # TODO: Refactor and write tests for this method
+  def clear_examination_boards_cache
+    return unless academic.current_orientation
+
+    academic.current_orientation.examination_boards.each do |examination_board|
+      # rubocop:disable Rails/SkipsModelValidations
+      examination_board.touch if examination_board.academic_activity == self
+      # rubocop:enable Rails/SkipsModelValidations
+    end
   end
 end


### PR DESCRIPTION
## Clear cache on examination boards 

**URL**: `http://localhost:3000/bancas-de-tcc`

<!--- Provide a general summary of your changes in the Title above. -->

<!-- Autolinked issue URL -->

Issue: #**no**

### Description

The examination boards list is cached and need to be updated when the academic send or update an activity.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] fix: A bug fix
- [ ] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [x] enhancement: An enhancement makes something better
- [ ] test: Adding missing tests or correcting existing tests
- [ ] perf: A code change that improves performance
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (e.g. prettier format)
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Changes to the build process or auxiliary tools and libraries functionality to not work as expected

---

Hours Required: 30
