### PR TITLE
Fixes two production issues related to file handling and error responses.

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,9 @@
 class ErrorsController < ApplicationController
   def show
-    render status_code.to_s, status: status_code
+    respond_to do |format|
+      format.html { render status_code.to_s, status: status_code }
+      format.any  { head status_code }
+    end
   end
 
   protected

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -4,5 +4,5 @@ CarrierWave.configure do |config|
   # Keep CarrierWave temporary cache out of the persisted uploads volume.
   # In production the final files are still stored under `public/uploads`,
   # but the transient cache must live in a writable runtime directory.
-  config.cache_dir = Rails.root.join('tmp', 'carrierwave')
+  config.cache_dir = Rails.root.join('tmp/carrierwave')
 end

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,1 +1,8 @@
 require 'carrierwave/orm/activerecord'
+
+CarrierWave.configure do |config|
+  # Keep CarrierWave temporary cache out of the persisted uploads volume.
+  # In production the final files are still stored under `public/uploads`,
+  # but the transient cache must live in a writable runtime directory.
+  config.cache_dir = Rails.root.join('tmp', 'carrierwave')
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
 
   root to: 'site#index'
 
+  # Search engines commonly probe this path even when no sitemap is published.
+  get 'sitemap.xml', to: 'errors#show', defaults: { code: 404, format: :xml }, as: :sitemap
+
   get 'documents/images',
       to: 'documents#images',
       as: 'document_images'

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -22,5 +22,14 @@ RSpec.describe ErrorsController do
         expect(response).to have_http_status(:internal_server_error)
       end
     end
+
+    context 'when the request format is xml' do
+      it 'responds with 404 without rendering an html template' do
+        get :show, params: { code: '404' }, format: :xml
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to be_blank
+      end
+    end
   end
 end

--- a/spec/requests/sitemap_spec.rb
+++ b/spec/requests/sitemap_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'Sitemap', type: :request do
+  it 'returns 404 for sitemap.xml without going through the page catch-all route' do
+    get '/sitemap.xml'
+
+    expect(response).to have_http_status(:not_found)
+    expect(response.media_type).to eq('application/xml')
+    expect(response.body).to be_blank
+  end
+end

--- a/spec/uploaders/carrier_wave_config_spec.rb
+++ b/spec/uploaders/carrier_wave_config_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'CarrierWave configuration' do
-  it 'stores the temporary cache in the app tmp directory' do
-    expect(PdfUploader.new.cache_dir).to eq(Rails.root.join('tmp', 'carrierwave').to_s)
-  end
-end

--- a/spec/uploaders/carrier_wave_config_spec.rb
+++ b/spec/uploaders/carrier_wave_config_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'CarrierWave configuration' do
+  it 'stores the temporary cache in the app tmp directory' do
+    expect(PdfUploader.new.cache_dir).to eq(Rails.root.join('tmp', 'carrierwave').to_s)
+  end
+end

--- a/spec/uploaders/pdf_uploader_carrier_wave_config_spec.rb
+++ b/spec/uploaders/pdf_uploader_carrier_wave_config_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+describe PdfUploader do
+  it 'stores the temporary cache in the app tmp directory' do
+    expect(described_class.new.cache_dir).to eq(Rails.root.join('tmp/carrierwave'))
+  end
+end


### PR DESCRIPTION
# Summary

  This branch fixes two production issues related to file handling and error responses.

  1. CarrierWave uploads were failing in production with Errno::EACCES because the temporary cache was being created under /rails/public/uploads/tmp, which was not writable for the app pr
     ocess. The fix moves CarrierWave’s temp cache to Rails.root/tmp/carrierwave while keeping final uploaded files in the existing public/uploads location.
  2. Requests to /sitemap.xml were producing a 500 instead of a 404. The route was falling through to the site page catch-all, then the error handler tried to render an HTML error template
     for an XML request. The fix adds explicit handling for /sitemap.xml and makes ErrorsController return the proper status for non-HTML formats without attempting to render missing
     templates.

# Changes

  - Configure CarrierWave temp cache directory in config/initializers/carrier_wave.rb:1
  - Add a spec covering the CarrierWave cache path in spec/uploaders/carrier_wave_config_spec.rb:1
  - Update app/controllers/errors_controller.rb:1 to handle non-HTML error responses safely
  - Add an explicit /sitemap.xml route in config/routes.rb:11
  - Add regression coverage in spec/controllers/errors_controller_spec.rb:1 and spec/requests/sitemap_spec.rb:1

#  Impact

  - Fixes production PDF upload failures without changing upload behavior for end users.
  - Prevents bogus 500s for missing XML resources and returns the correct 404 instead.

#  Validation

  - Upload flow should succeed again for AcademicActivity attachments in production.
  - GET /sitemap.xml should now return 404 directly instead of cascading into a 500.
  - Specs added for both regressions.