### PR TITLE
fix: corrige modal de apontamentos e input de calendário

### DIFF
--- a/app/components/forms/datetimepicker_component.html.erb
+++ b/app/components/forms/datetimepicker_component.html.erb
@@ -1,4 +1,7 @@
-<div class="form-group" data-controller="forms--datetimepicker" data-forms--datetimepicker-id-value="<%= id %>">
+<div class="form-group"
+     data-controller="forms--datetimepicker"
+     data-forms--datetimepicker-id-value="<%= id %>"
+     data-forms--datetimepicker-enable-time-value="<%= enable_time %>">
   <label for="<%= id %>" class="form-control-label string required">
     <%= label %>
     <abbr title="obrigatório">*</abbr>
@@ -9,9 +12,14 @@
       type="text"
       class="<%= input_class %>"
       data-forms--datetimepicker-target="field"
-      value="<%= datetime %>"
+      data-action="beforeinput->forms--datetimepicker#allowOnlyDateCharacters input->forms--datetimepicker#maskManualValue blur->forms--datetimepicker#commitManualValue change->forms--datetimepicker#commitManualValue keydown.enter->forms--datetimepicker#submitManualValue"
+      value="<%= field_value %>"
       <%= 'disabled' if disabled %>
-      placeholder="DD/MM/YYYY HH:mm"
+      placeholder="<%= placeholder %>"
+      maxlength="<%= maxlength %>"
+      inputmode="numeric"
+      pattern="<%= pattern %>"
+      title="<%= placeholder %>"
       autocomplete="off"
     >
     <div class="input-group-append" data-action="click->forms--datetimepicker#toggle">

--- a/app/components/forms/datetimepicker_component.rb
+++ b/app/components/forms/datetimepicker_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Forms::DatetimepickerComponent < ViewComponent::Base
-  attr_reader :name, :id, :label, :datetime, :disabled, :errors
+  attr_reader :name, :id, :label, :datetime, :disabled, :errors, :enable_time
 
   def initialize(name:, id:, label:, **options)
     @name = name
@@ -10,6 +10,7 @@ class Forms::DatetimepickerComponent < ViewComponent::Base
     @datetime = options.fetch(:datetime, nil)
     @disabled = options.fetch(:disabled, false)
     @errors = options.fetch(:errors, []) || []
+    @enable_time = options.fetch(:enable_time, true)
   end
 
   def input_class
@@ -21,5 +22,27 @@ class Forms::DatetimepickerComponent < ViewComponent::Base
 
   def errors?
     errors.any?
+  end
+
+  def input_format
+    enable_time ? '%d/%m/%Y %H:%M' : '%d/%m/%Y'
+  end
+
+  def placeholder
+    enable_time ? 'DD/MM/YYYY HH:mm' : 'DD/MM/YYYY'
+  end
+
+  def maxlength
+    enable_time ? 16 : 10
+  end
+
+  def pattern
+    enable_time ? '\\d{2}/\\d{2}/\\d{4} \\d{2}:\\d{2}' : '\\d{2}/\\d{2}/\\d{4}'
+  end
+
+  def field_value
+    return if datetime.blank?
+
+    datetime.strftime(input_format)
   end
 end

--- a/app/javascript/controllers/forms/datetimepicker_controller.js
+++ b/app/javascript/controllers/forms/datetimepicker_controller.js
@@ -4,19 +4,22 @@ import { Portuguese } from "flatpickr/dist/l10n/pt";
 
 export default class extends Controller {
   static targets = ["field", "input"];
-  static values = { id: String };
+  static values = { id: String, enableTime: Boolean };
 
   connect() {
     const initialDate = this.parseInitialDate();
+    this.beforeSubmit = this.commitManualValue.bind(this);
+    this.form = this.element.closest("form");
     
     this.picker = flatpickr(this.fieldTarget, {
-      enableTime: true,
-      time_24hr: true,
-      dateFormat: "d/m/Y H:i",
+      enableTime: this.enableTimeValue,
+      time_24hr: this.enableTimeValue,
+      dateFormat: this.enableTimeValue ? "d/m/Y H:i" : "d/m/Y",
       locale: Portuguese,
       defaultDate: initialDate,
       allowInput: true,
-      onChange: this.updateHidden.bind(this)
+      onChange: this.updateHidden.bind(this),
+      onClose: this.commitManualValue.bind(this)
     });
 
     this.setupDateValidation();
@@ -28,9 +31,17 @@ export default class extends Controller {
       this.picker.setDate(now);
       this.updateHidden([now], "");
     }
+
+    if (this.form) {
+      this.form.addEventListener("submit", this.beforeSubmit);
+    }
   }
 
   disconnect() {
+    if (this.form) {
+      this.form.removeEventListener("submit", this.beforeSubmit);
+    }
+
     if (this.picker) {
       this.picker.destroy();
     }
@@ -43,35 +54,216 @@ export default class extends Controller {
     }
   }
 
+  submitManualValue(event) {
+    event.preventDefault();
+    this.commitManualValue();
+    this.fieldTarget.blur();
+  }
+
+  allowOnlyDateCharacters(event) {
+    if (this.handleSeparatorDeletion(event)) return;
+    if (event.inputType && !event.inputType.startsWith("insert")) return;
+    if (!event.data) return;
+
+    if (!/^[\d/: ]+$/.test(event.data)) {
+      event.preventDefault();
+    }
+  }
+
+  handleSeparatorDeletion(event) {
+    if (!["deleteContentBackward", "deleteContentForward"].includes(event.inputType)) {
+      return false;
+    }
+
+    const selectionStart = this.fieldTarget.selectionStart;
+    const selectionEnd = this.fieldTarget.selectionEnd;
+    if (selectionStart === null || selectionEnd === null || selectionStart !== selectionEnd) {
+      return false;
+    }
+
+    const value = this.fieldTarget.value;
+    const direction = event.inputType === "deleteContentBackward" ? -1 : 1;
+    const separatorIndex = direction === -1 ? selectionStart - 1 : selectionStart;
+    if (!this.isSeparator(value[separatorIndex])) return false;
+
+    event.preventDefault();
+
+    const digits = value.replace(/\D/g, "");
+    const digitOffset = value.slice(0, selectionStart).replace(/\D/g, "").length;
+    const digitIndex = direction === -1 ? digitOffset - 1 : digitOffset;
+    if (digitIndex < 0 || digitIndex >= digits.length) return true;
+
+    const nextDigits = `${digits.slice(0, digitIndex)}${digits.slice(digitIndex + 1)}`;
+    const maskedValue = this.maskValue(nextDigits);
+
+    this.fieldTarget.value = maskedValue;
+    this.restoreCaretPosition(maskedValue, digitIndex, { skipSeparators: false });
+    this.syncHiddenFromField();
+
+    return true;
+  }
+
+  isSeparator(character) {
+    return /[/: ]/.test(character || "");
+  }
+
+  maskManualValue() {
+    if (this.fieldTarget.disabled) return;
+
+    const rawValue = this.fieldTarget.value;
+    const digitOffset = this.countDigitsBeforeCaret(rawValue);
+    const maskedValue = this.maskValue(rawValue);
+
+    this.fieldTarget.value = maskedValue;
+    this.restoreCaretPosition(maskedValue, digitOffset);
+
+    this.syncHiddenFromField();
+  }
+
+  syncHiddenFromField() {
+    const parsedDate = this.parseDateValue(this.fieldTarget.value);
+    if (parsedDate) {
+      this.updateHidden([parsedDate], { updateField: false });
+    } else {
+      this.inputTarget.value = "";
+    }
+  }
+
+  commitManualValue() {
+    if (this.fieldTarget.disabled) return;
+
+    const rawValue = this.fieldTarget.value?.trim();
+    if (!rawValue) {
+      this.inputTarget.value = "";
+      return;
+    }
+
+    const parsedDate = this.parseDateValue(rawValue);
+    if (!parsedDate) {
+      this.inputTarget.value = "";
+      return;
+    }
+
+    this.picker.setDate(parsedDate, true);
+  }
+
+  maskValue(value) {
+    const digits = value.replace(/\D/g, "").slice(0, this.enableTimeValue ? 12 : 8);
+    const dateParts = [
+      digits.slice(0, 2),
+      digits.slice(2, 4),
+      digits.slice(4, 8)
+    ].filter(Boolean);
+
+    let maskedValue = dateParts.join("/");
+    if (!this.enableTimeValue || digits.length <= 8) return maskedValue;
+
+    const timeDigits = digits.slice(8, 12);
+    const timeParts = [
+      timeDigits.slice(0, 2),
+      timeDigits.slice(2, 4)
+    ].filter(Boolean);
+
+    return `${maskedValue} ${timeParts.join(":")}`;
+  }
+
+  countDigitsBeforeCaret(value) {
+    const caretPosition = this.fieldTarget.selectionStart ?? value.length;
+    return value.slice(0, caretPosition).replace(/\D/g, "").length;
+  }
+
+  restoreCaretPosition(value, digitOffset, options = {}) {
+    if (document.activeElement !== this.fieldTarget) return;
+
+    let digitCount = 0;
+    let caretPosition = value.length;
+
+    if (digitOffset === 0) {
+      caretPosition = 0;
+    } else {
+      for (let index = 0; index < value.length; index++) {
+        if (/\d/.test(value[index])) digitCount += 1;
+
+        if (digitCount === digitOffset) {
+          caretPosition = index + 1;
+          break;
+        }
+      }
+    }
+
+    while (options.skipSeparators !== false && caretPosition < value.length && /\D/.test(value[caretPosition])) {
+      caretPosition += 1;
+    }
+
+    this.fieldTarget.setSelectionRange(caretPosition, caretPosition);
+  }
+
   parseInitialDate() {
     const value = this.inputTarget.value;
     if (!value || value === "") {
       return new Date();
     }
 
-    const match = value.match(/(\d{2})\/(\d{2})\/(\d{4})\s+(\d{2}):(\d{2})/);
-    if (match) {
-      const [, day, month, year, hours, minutes] = match;
-      return new Date(year, month - 1, day, hours, minutes);
-    }
-
-    const isoMatch = value.match(/(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2})/);
-    if (isoMatch) {
-      const [, year, month, day, hours, minutes] = isoMatch;
-      return new Date(year, month - 1, day, hours, minutes);
-    }
-
-    const parsed = new Date(value);
-    return isNaN(parsed.getTime()) ? new Date() : parsed;
+    return this.parseDateValue(value) || new Date();
   }
 
-  updateHidden(selectedDates) {
+  parseDateValue(value) {
+    if (!value) return null;
+
+    const match = value.match(/^(\d{2})\/(\d{2})\/(\d{4})\s+(\d{2}):(\d{2})$/);
+    if (match) {
+      const [, day, month, year, hours, minutes] = match;
+      return this.buildDate(year, month, day, hours, minutes);
+    }
+
+    const isoMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2})/);
+    if (isoMatch) {
+      const [, year, month, day, hours, minutes] = isoMatch;
+      return this.buildDate(year, month, day, hours, minutes);
+    }
+
+    const dateOnlyMatch = value.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (dateOnlyMatch) {
+      const [, day, month, year] = dateOnlyMatch;
+      return this.buildDate(year, month, day, 0, 0);
+    }
+
+    const isoDateOnlyMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (isoDateOnlyMatch) {
+      const [, year, month, day] = isoDateOnlyMatch;
+      return this.buildDate(year, month, day, 0, 0);
+    }
+
+    return null;
+  }
+
+  buildDate(year, month, day, hours, minutes) {
+    const date = new Date(year, month - 1, day, hours, minutes);
+    const isValid =
+      date.getFullYear() === Number(year) &&
+      date.getMonth() === Number(month) - 1 &&
+      date.getDate() === Number(day) &&
+      date.getHours() === Number(hours) &&
+      date.getMinutes() === Number(minutes);
+
+    return isValid ? date : null;
+  }
+
+  updateHidden(selectedDates, options = {}) {
     if (selectedDates.length > 0) {
       const date = selectedDates[0];
-      const displayFormat = flatpickr.formatDate(date, "d/m/Y H:i");
-      const railsFormat = flatpickr.formatDate(date, "Y-m-d H:i:S");
+      const displayFormat = flatpickr.formatDate(
+        date,
+        this.enableTimeValue ? "d/m/Y H:i" : "d/m/Y"
+      );
+      const railsFormat = flatpickr.formatDate(
+        date,
+        this.enableTimeValue ? "Y-m-d H:i:S" : "Y-m-d"
+      );
       
-      this.fieldTarget.value = displayFormat;
+      if (options.updateField !== false) {
+        this.fieldTarget.value = displayFormat;
+      }
       this.inputTarget.value = railsFormat;
       
       this.notifyLinkedPickers();

--- a/app/views/responsible/calendars/_form.html.erb
+++ b/app/views/responsible/calendars/_form.html.erb
@@ -23,6 +23,7 @@
           id: "calendar_start_date",
           label: Calendar.human_attribute_name("start_date"),
           datetime: @calendar.start_date,
+          enable_time: false,
           errors: @calendar.errors[:start_date]
         ) %>
       </div>
@@ -33,6 +34,7 @@
           id: "calendar_end_date",
           label: Calendar.human_attribute_name("end_date"),
           datetime: @calendar.end_date,
+          enable_time: false,
           errors: @calendar.errors[:end_date]
         ) %>
       </div>

--- a/spec/features/responsible/calendars/calendars_create_spec.rb
+++ b/spec/features/responsible/calendars/calendars_create_spec.rb
@@ -26,13 +26,13 @@ describe 'Calendar::create', :js do
           find('span.custom-control-label', text: semester_text).click
         end
 
-        start_value = attributes[:start_date].strftime('%Y-%m-%d')
-        end_value   = attributes[:end_date].strftime('%Y-%m-%d')
+        start_value = attributes[:start_date].strftime('%d/%m/%Y')
+        end_value   = attributes[:end_date].strftime('%d/%m/%Y')
 
-        page.execute_script(<<~JS)
-          document.querySelector('#calendar_start_date').value = '#{start_value}';
-          document.querySelector('#calendar_end_date').value   = '#{end_value}';
-        JS
+        first('input[data-forms--datetimepicker-target="field"]').set(start_value)
+        all('input[data-forms--datetimepicker-target="field"]')[1].set(end_value)
+
+        page.find('body').click
 
         submit_form('input[name="commit"]')
 

--- a/spec/features/responsible/calendars/calendars_update_spec.rb
+++ b/spec/features/responsible/calendars/calendars_update_spec.rb
@@ -30,16 +30,13 @@ describe 'Calendar::update', :js do
           find('span.custom-control-label', text: semester_text).click
         end
 
-        start_value = attributes[:start_date].strftime('%Y-%m-%d')
-        end_value   = attributes[:end_date].strftime('%Y-%m-%d')
+        start_value = attributes[:start_date].strftime('%d/%m/%Y')
+        end_value   = attributes[:end_date].strftime('%d/%m/%Y')
 
-        page.execute_script(<<~JS)
-          var s = document.querySelector('input[name="calendar[start_date]"]');
-          if (s) { s.value = '#{start_value}'; s.dispatchEvent(new Event('change', { bubbles: true })); }
+        first('input[data-forms--datetimepicker-target="field"]').set(start_value)
+        all('input[data-forms--datetimepicker-target="field"]')[1].set(end_value)
 
-          var e = document.querySelector('input[name="calendar[end_date]"]');
-          if (e) { e.value = '#{end_value}'; e.dispatchEvent(new Event('change', { bubbles: true })); }
-        JS
+        page.find('body').click
         submit_form('input[name="commit"]')
 
         expect(page).to have_current_path responsible_calendars_tcc_two_path


### PR DESCRIPTION
## Tipo de mudança

- [x] Correção
- [x] Testes
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação

## Descrição

- Ajusta o date-picker dos formulários de calendário para campos somente com data.
- Adiciona máscara e validação para entrada manual no formato DD/MM/YYYY.
- Corrige a edição pelo teclado, preservando a posição do cursor ao alterar dia, mês ou ano.
- Corrige o comportamento ao apagar valores próximos aos separadores /, evitando que o campo trave.
- Mantém o campo visível sincronizado com o input hidden usado pelo Rails.
- Atualiza os specs de criação e edição de calendários para preencher o campo visível do date-picker.

## Testes

- [x] `./run rspec`
- [x] `./run eslint`
- [x] `./run rubocop` nos arquivos alterados
