### PR TITLE
Replace legacy markdown reader and Bootstrap tooltip integrations, improve  note range selector

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     capybara-screenshot (1.0.27)
       capybara (>= 1.0, < 4)
       launchy
-    carrierwave (3.1.2)
+    carrierwave (3.1.3)
       activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
       addressable (~> 2.6)
@@ -222,6 +222,7 @@ GEM
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
     ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     formatador (1.2.3)
@@ -265,7 +266,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jaro_winkler (1.7.0)
-    json (2.19.5)
+    json (2.19.9)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     kamal (2.11.0)
@@ -349,7 +350,7 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.8)
       connection_pool (>= 2.2.4, < 4)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-ldap (0.20.0)
@@ -375,6 +376,8 @@ GEM
     nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -410,7 +413,7 @@ GEM
       reline (>= 0.6.0)
     psych (3.3.4)
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -604,6 +607,7 @@ GEM
     sqlite3 (2.9.4-aarch64-linux-musl)
     sqlite3 (2.9.4-arm-linux-gnu)
     sqlite3 (2.9.4-arm-linux-musl)
+    sqlite3 (2.9.4-arm64-darwin)
     sqlite3 (2.9.4-x86_64-linux-gnu)
     sqlite3 (2.9.4-x86_64-linux-musl)
     sshkit (1.25.0)
@@ -621,6 +625,7 @@ GEM
     thor (1.5.0)
     thruster (0.1.21)
     thruster (0.1.21-aarch64-linux)
+    thruster (0.1.21-arm64-darwin)
     thruster (0.1.21-x86_64-linux)
     tilt (2.7.0)
     timeout (0.6.1)
@@ -673,6 +678,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  arm64-darwin-24
   x86_64-linux-gnu
   x86_64-linux-musl
 

--- a/app/assets/stylesheets/customizations/examination_boards.css
+++ b/app/assets/stylesheets/customizations/examination_boards.css
@@ -55,6 +55,17 @@ input.form-control-range.is-valid:focus::-moz-range-thumb {
   box-shadow: none;
 }
 
+.appointment-text-modal .modal-body {
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.appointment-text-modal .modal-body pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .range-label {
   width: 100%;
 }

--- a/app/assets/stylesheets/customizations/examination_boards.css
+++ b/app/assets/stylesheets/customizations/examination_boards.css
@@ -71,9 +71,6 @@ input.form-control-range.is-valid:focus::-moz-range-thumb {
 }
 
 .range-summary-card {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
   margin-bottom: 0.75rem;
 }
 
@@ -90,10 +87,6 @@ input.form-control-range.is-valid:focus::-moz-range-thumb {
   border-color: #467fcf;
   background: linear-gradient(180deg, #edf4ff 0%, #dceaff 100%);
   box-shadow: 0 10px 24px rgba(70, 127, 207, 0.16);
-}
-
-.range-summary-item-selected {
-  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
 }
 
 .range-summary-title {
@@ -117,8 +110,39 @@ input.form-control-range.is-valid:focus::-moz-range-thumb {
   color: #1d4fa8;
 }
 
-@media (max-width: 767.98px) {
-  .range-summary-card {
-    grid-template-columns: 1fr;
-  }
+.range-slider {
+  position: relative;
+  padding-top: 2.75rem;
+}
+
+.range-slider .form-control-range {
+  margin: 0;
+}
+
+.range-selected-value {
+  position: absolute;
+  top: 0;
+  min-width: 2.5rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.45rem;
+  background: #1d4fa8;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.range-selected-value::after {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border: 0.35rem solid transparent;
+  border-top-color: #1d4fa8;
+  content: "";
+  transform: translateX(-50%);
 }

--- a/app/components/forms/image_preview_component.html.erb
+++ b/app/components/forms/image_preview_component.html.erb
@@ -2,8 +2,8 @@
   <!-- Box de preview quando há imagem -->
   <div id="box-image-preview" 
        data-forms--image-preview-target="previewBox"
-       data-toggle="tooltip" 
-       data-placement="left" 
+       data-controller="ui--tooltip"
+       data-bs-placement="left"
        title="Editar imagem"
        style="<%= 'display: none;' unless image? %>">
     <div class="input-field image_preview">
@@ -63,4 +63,3 @@
     </div>
   <% end %>
 </div>
-

--- a/app/inputs/range_tabler_input.rb
+++ b/app/inputs/range_tabler_input.rb
@@ -3,12 +3,11 @@ class RangeTablerInput < SimpleForm::Inputs::Base
     merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
     value = object.public_send(attribute_name) || merged_input_options[:value] || 0
 
-    @builder.range_field(attribute_name,
-                         build_input_options(merged_input_options, value)) + error_html
+    slider_html(merged_input_options, value) + error_html
   end
 
   def label(_wrapper_options)
-    value = object.public_send(attribute_name) || input_html_options[:value] || 0
+    value = object.public_send(attribute_name)
 
     template.tag.label(class: 'form-label range-label') do
       template.concat summary_card(value)
@@ -16,6 +15,16 @@ class RangeTablerInput < SimpleForm::Inputs::Base
   end
 
   private
+
+  def slider_html(merged_input_options, value)
+    template.tag.div(class: 'range-slider') do
+      template.concat selected_note_output(value)
+      template.concat @builder.range_field(
+        attribute_name,
+        build_input_options(merged_input_options, value)
+      )
+    end
+  end
 
   def build_input_options(merged_input_options, value)
     merged_input_options.deep_merge(
@@ -31,29 +40,26 @@ class RangeTablerInput < SimpleForm::Inputs::Base
   end
 
   def input_css_class(custom_classes)
-    [custom_classes, 'form-control-range', input_error_class].compact.join(' ')
+    [custom_classes, 'form-control-range pl-0 pr-0', input_error_class].compact.join(' ')
   end
 
   def summary_card(value)
     template.tag.div(class: 'range-summary-card') do
       template.concat current_note_card(value)
-      template.concat selected_note_card(value)
     end
   end
 
   def current_note_card(value)
     template.tag.div(class: 'range-summary-item range-summary-item-current') do
-      title = I18n.t('activerecord.attributes.examination_board_note.actual_note')
+      title = note_title(value)
       template.concat summary_title(title)
-      template.concat summary_value(value)
+      template.concat summary_value(value) unless value.nil?
     end
   end
 
-  def selected_note_card(value)
-    template.tag.div(class: 'range-summary-item range-summary-item-selected') do
-      template.concat summary_title(I18n.t('views.labels.selected.f'))
-      template.concat selected_note_span(value)
-    end
+  def note_title(value)
+    key = value.nil? ? 'unassigned_note' : 'actual_note'
+    I18n.t("activerecord.attributes.examination_board_note.#{key}")
   end
 
   def summary_title(text)
@@ -64,9 +70,10 @@ class RangeTablerInput < SimpleForm::Inputs::Base
     template.content_tag(:span, value, class: 'range-summary-value')
   end
 
-  def selected_note_span(value)
-    template.tag.span(value, class: 'range-summary-value',
-                             data: { range_tabler_selected_note: true })
+  def selected_note_output(value)
+    template.tag.output(value,
+                        class: 'range-selected-value',
+                        data: { range_tabler_selected_note: true })
   end
 
   def error_html

--- a/app/javascript/controllers/forms/range_tabler_controller.js
+++ b/app/javascript/controllers/forms/range_tabler_controller.js
@@ -2,17 +2,33 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   connect() {
+    this.resizeObserver = new ResizeObserver(() => this.update());
+    this.resizeObserver.observe(this.element);
     this.update();
   }
 
+  disconnect() {
+    this.resizeObserver?.disconnect();
+  }
+
   update() {
-    const value = this.element.value || 0;
-    const wrapper = this.element.closest(".input, .form-group, .mb-3") || this.element.parentElement;
+    const value = Number(this.element.value || 0);
+    const min = Number(this.element.min || 0);
+    const max = Number(this.element.max || 100);
+    const range = max - min;
+    const rawRatio = range > 0 ? (value - min) / range : 0;
+    const ratio = Math.min(1, Math.max(0, rawRatio));
+    const thumbWidth = 14;
+    const left = this.element.offsetLeft
+      + (thumbWidth / 2)
+      + (ratio * (this.element.clientWidth - thumbWidth));
+    const selectedNote = this.element.parentElement.querySelector(
+      "[data-range-tabler-selected-note]"
+    );
 
-    if (!wrapper) return;
-
-    const selectedNote = wrapper.querySelector("[data-range-tabler-selected-note]");
-
-    if (selectedNote) selectedNote.textContent = value;
+    if (selectedNote) {
+      selectedNote.textContent = value;
+      selectedNote.style.left = `${left}px`;
+    }
   }
 }

--- a/app/views/academics/activities/_document_card.html.erb
+++ b/app/views/academics/activities/_document_card.html.erb
@@ -51,9 +51,8 @@
       </div>
 
       <div class="card-body">
-         <p>
-            <markdown-reader content="<%= @academic_activity.additional_instructions %>" />
-            </p>
-         </div>
+         <div data-controller="markdown--viewer"
+              data-markdown="<%= @academic_activity.additional_instructions %>"></div>
       </div>
-   <% end %>
+   </div>
+<% end %>

--- a/app/views/academics/calendars/_calendar.html.erb
+++ b/app/views/academics/calendars/_calendar.html.erb
@@ -3,7 +3,7 @@
     <td><%= link_to calendar.year_with_semester, academics_calendar_activities_path(calendar) %></td>
     <td><%= t("enums.tcc.#{calendar.tcc}") %></td>
     <td>
-      <span data-toggle="tooltip" title="<%= orientation.title %>">
+      <span data-controller="ui--tooltip" title="<%= orientation.title %>">
         <%= orientation.short_title %>
       </span>
     </td>
@@ -15,11 +15,11 @@
     </td>
     <td>
       <%= link_to(academics_calendar_orientation_activities_path(calendar, orientation)) do %>
-        <i class="far fa-file-alt" data-toggle="tooltip" title="Visualizar atividades"></i>
+        <i class="far fa-file-alt" data-controller="ui--tooltip" title="Visualizar atividades"></i>
       <% end %>
 
       <%= link_to(academics_calendar_orientation_documents_path(calendar, orientation)) do %>
-        <i class="fe fe-file" data-toggle="tooltip" title="Visualizar documentos"></i>
+        <i class="fe fe-file" data-controller="ui--tooltip" title="Visualizar documentos"></i>
       <% end %>
     </td>
   </tr>

--- a/app/views/academics/tso_requests/show.html.erb
+++ b/app/views/academics/tso_requests/show.html.erb
@@ -41,13 +41,13 @@
         <% end %>
       </p>
     <% end %>
-    <p>
+    <div>
       <strong>
         <%= Document.human_attribute_name('justification') %>:
       </strong>
-      <markdown-reader
-        content="<%= @document.request['requester']['justification'] %>" />
-    </p>
+      <div data-controller="markdown--viewer"
+           data-markdown="<%= @document.request['requester']['justification'] %>"></div>
+    </div>
     <p>
       <strong>
         <%= Document.human_attribute_name('created_at') %>:
@@ -72,4 +72,3 @@
     edit_academics_tso_request_path(@document),
     class: 'btn btn-primary ml-auto' %>
 </div>
-

--- a/app/views/external_members/calendars/_calendar.html.erb
+++ b/app/views/external_members/calendars/_calendar.html.erb
@@ -3,7 +3,7 @@
     <td><%= link_to calendar.year_with_semester, external_members_calendar_activities_path(calendar) %></td>
     <td><%= t("enums.tcc.#{calendar.tcc}") %></td>
     <td>
-      <span data-toggle="tooltip" title="<%= orientation.title %>">
+      <span data-controller="ui--tooltip" title="<%= orientation.title %>">
         <%= orientation.short_title %>
       </span>
     </td>

--- a/app/views/external_members/examination_boards/_evaluator_note_form.html.erb
+++ b/app/views/external_members/examination_boards/_evaluator_note_form.html.erb
@@ -1,25 +1,26 @@
 <div class="card">
-   <div class="card-header">
-      <strong class="mr-1">
-         <%= t("views.title.notes.#{@examination_board.orientation.academic.gender}") %>:
-      </strong>
-      <%= @examination_board.orientation.academic.name %>
-   </div>
-   <div class="card-body">
-      <%= simple_form_for(@examination_board_note, url: url) do |f| %>
-         <div class="form-inputs">
-            <%= f.input :note, as: :range_tabler, hint: t('hints.note.between') %>
-         </div>
+  <div class="card-header">
+    <strong class="mr-1">
+      <%= t("views.title.notes.#{@examination_board.orientation.academic.gender}") %>:
+    </strong>
+    <%= @examination_board.orientation.academic.name %>
+  </div>
+  <div class="card-body">
+    <%= simple_form_for(@examination_board_note, url: url) do |f| %>
+      <div class="form-inputs">
+        <%= f.input :note, as: :range_tabler, hint: t('hints.note.between') %>
+      </div>
 
-         <%= f.hidden_field :external_member_id, value: current_external_member.id %>
-         <%= f.hidden_field :examination_board_id, value: @examination_board.id %>
+      <%= f.hidden_field :external_member_id, value: current_external_member.id %>
+      <%= f.hidden_field :examination_board_id, value: @examination_board.id %>
 
-         <div class="d-flex mt-4">
-            <%= f.button :submit,
-                         t('views.buttons.save'),
-                         id: 'examination_board_note_button',
-                         class: 'btn btn-primary ml-auto' %>
-         </div>
-      <% end %>
-   </div>
+      <div class="d-flex mt-4">
+        <%= f.button :submit,
+                     t('views.buttons.save'),
+                     id: 'examination_board_note_button',
+                     data: { turbo_submits_with: t('views.buttons.save') },
+                     class: 'btn btn-primary ml-auto' %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/professors/requests/show.html.erb
+++ b/app/views/professors/requests/show.html.erb
@@ -15,13 +15,13 @@
       </strong>
       <%= @document.orientation.academic_with_calendar %>
     </p>
-    <p>
+    <div>
       <strong>
         <%= Document.human_attribute_name('justification') %>:
       </strong>
-      <markdown-reader
-        content="<%= @document.request['requester']['justification'] %>" />
-    </p>
+      <div data-controller="markdown--viewer"
+           data-markdown="<%= @document.request['requester']['justification'] %>"></div>
+    </div>
     <p>
       <strong>
         <%= Document.human_attribute_name('created_at') %>:

--- a/app/views/responsible/professors/_calendar.html.erb
+++ b/app/views/responsible/professors/_calendar.html.erb
@@ -5,16 +5,16 @@
   <td><%= short_date(calendar.created_at) %></td>
   <td>
     <%= link_to(responsible_calendar_path(calendar)) do %>
-      <i class="fe fe-search" data-toggle="tooltip" title="Show"></i>
+      <i class="fe fe-search" data-controller="ui--tooltip" title="Show"></i>
     <% end %>
     <%= link_to(edit_responsible_calendar_path(calendar)) do %>
-      <i class="fe fe-edit" data-toggle="tooltip" title="Editar"></i>
+      <i class="fe fe-edit" data-controller="ui--tooltip" title="Editar"></i>
     <% end %>
     <%= link_to responsible_calendar_path(calendar),
       method: :delete,
       data: { confirm: t('prompt.confirm') },
       class: 'destroy' do %>
-      <i class="fe fe-trash" data-toggle="tooltip" title="Delete"></i>
+      <i class="fe fe-trash" data-controller="ui--tooltip" title="Delete"></i>
     <% end %>
   </td>
 </tr>

--- a/app/views/shared/examination_boards/_academic_activity.html.erb
+++ b/app/views/shared/examination_boards/_academic_activity.html.erb
@@ -43,9 +43,8 @@
     </div>
 
     <div class="card-body">
-      <p>
-        <markdown-reader content="<%= academic_activity.additional_instructions %>" />
-      </p>
+      <div data-controller="markdown--viewer"
+           data-markdown="<%= academic_activity.additional_instructions %>"></div>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/examination_boards/_appointment_text_modal.html.erb
+++ b/app/views/shared/examination_boards/_appointment_text_modal.html.erb
@@ -1,21 +1,21 @@
-<div class="modal fade" id="appoint-text-<%= response.id %>" tabindex="-1" role="dialog" aria-labelledby="appointment-modal-label-<%= response.id %>" aria-hidden="true">
-   <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered" role="document">
-      <div class="modal-content">
-         <div class="modal-header">
-            <span class="text-muted mr-1">Apontamentos do avaliador </span>
-            <h5 class="modal-title" id="appointment-modal-label-<%= response.id %>">
-               <%= response.evaluator.name %>
-            </h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            </button>
-         </div>
-         <div class="modal-body">
-            <markdown-reader content="<%= response.appointments_text %>" />
-         </div>
-
-         <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
-         </div>
+<div class="modal fade appointment-text-modal" id="appoint-text-<%= response.id %>" tabindex="-1" role="dialog" aria-labelledby="appointment-modal-label-<%= response.id %>" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <span class="text-muted mr-1">Apontamentos do avaliador </span>
+        <h5 class="modal-title" id="appointment-modal-label-<%= response.id %>">
+          <%= response.evaluator.name %>
+        </h5>
+        <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
+        </button>
       </div>
-   </div>
+      <div class="modal-body">
+        <div data-controller="markdown--viewer" data-markdown="<%= response.appointments_text %>"></div>
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/shared/examination_boards/_evaluated_status.html.erb
+++ b/app/views/shared/examination_boards/_evaluated_status.html.erb
@@ -32,8 +32,11 @@
               </td>
               <td>
                 <%= link_to_if response.appointments_text?,
-                                 t("helpers.boolean.#{response.appointments_text?}"),'#',  
-                                 data: { toggle: "modal", target: "#appoint-text-#{response.id}" } %>
+                                 t("helpers.boolean.#{response.appointments_text?}"), '#',
+                                 data: {
+                                   bs_toggle: 'modal',
+                                   bs_target: "#appoint-text-#{response.id}"
+                                 } %>
 
                 <%= render('shared/examination_boards/appointment_text_modal', response: response) if response.appointments_text? %>
               </td>

--- a/app/views/shared/orientations/_tbody.html.erb
+++ b/app/views/shared/orientations/_tbody.html.erb
@@ -1,6 +1,6 @@
 <td class="text-center status-width">
   <% cache orientation.status do %>
-    <span data-toggle="tooltip" title="<%= orientation.status %>">
+    <span data-controller="ui--tooltip" title="<%= orientation.status %>">
       <orientation-status
         :index="true"
         label="<%= orientation.status %>"
@@ -20,7 +20,7 @@
 </td>
 
 <td>
-  <span data-toggle="tooltip" title="<%= orientation.title %>">
+  <span data-controller="ui--tooltip" title="<%= orientation.title %>">
     <%= orientation.short_title %>
   </span>
 </td>

--- a/app/views/site/professor.html.erb
+++ b/app/views/site/professor.html.erb
@@ -41,14 +41,15 @@
       </strong>
       <%= @professor.professor_type.name %>
     </p>
-    <p>
+    <div>
       <strong>
         <%= Professor.human_attribute_name('working_area') %>:
       </strong>
       <div class="form-fieldset">
-        <markdown-reader content="<%= @professor.working_area %>" />
+        <div data-controller="markdown--viewer"
+             data-markdown="<%= @professor.working_area %>"></div>
       </div>
-    </p>
+    </div>
   </div>
 </div>
 

--- a/app/views/site/professors/_professor.html.erb
+++ b/app/views/site/professors/_professor.html.erb
@@ -10,7 +10,7 @@
   <td><%= professor.email %></td>
   <td class="text-center">
     <%= link_to professor.lattes, target: '_blank' do %>
-      <i class="fas fa-external-link-alt" data-toggle="tooltip" title="lattes"></i>
+      <i class="fas fa-external-link-alt" data-controller="ui--tooltip" title="lattes"></i>
     <% end %>
   </td>
   <td><%= t("helpers.boolean.#{professor.available_advisor}") %></td>

--- a/app/views/tcc_one_professors/examination_boards/_examination_board.html.erb
+++ b/app/views/tcc_one_professors/examination_boards/_examination_board.html.erb
@@ -5,14 +5,14 @@
    <td>
       <% unless examination_board.monograph? %>
          <%= link_to(edit_tcc_one_professors_examination_board_path(examination_board)) do %>
-            <i class="fe fe-edit" data-toggle="tooltip" title="<%= t('titles.edit') %>"></i>
+            <i class="fe fe-edit" data-controller="ui--tooltip" title="<%= t('titles.edit') %>"></i>
          <% end %>
 
          <%= link_to tcc_one_professors_examination_board_path(examination_board),
                   method: :delete,
                   data: { confirm: t('prompt.confirm') },
                   class: 'destroy' do %>
-            <i class="fe fe-trash" data-toggle="tooltip" title="<%= t('titles.delete') %>"></i>
+            <i class="fe fe-trash" data-controller="ui--tooltip" title="<%= t('titles.delete') %>"></i>
          <% end %>
       <% end %>
    </td>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -609,7 +609,8 @@ pt-BR:
         evaluator: "Avaliador"
         note: "Nota:"
         note_assigned: "Nota atribuída"
-        actual_note: 'Nota Atual'
+        actual_note: 'Nota'
+        unassigned_note: 'Nota não atribuída'
         appointment_file: "Apontamentos em arquivo"
         appointment_text: "Apontamentos em texto"
         appointments: "Apontamentos"


### PR DESCRIPTION
## Summary

This PR modernizes UI integrations by replacing legacy markdown rendering and Bootstrap tooltip usage with Stimulus-based controllers. It also updates examination board appointment modals to be compatible with Bootstrap 5 and improves markdown content rendering inside modals. And finally improve examination board range selector.

## Changes

### Markdown rendering migration

Replaced the legacy `<markdown-reader>` component with the `markdown--viewer` Stimulus controller across the application, including:

* Academic activity cards
* TSO requests
* Professor requests
* Examination board activity views
* Professor profile pages
* Appointment text modals

### Tooltip migration

Replaced legacy Bootstrap tooltip attributes (`data-toggle="tooltip"`) with the `ui--tooltip` Stimulus controller in:

* Calendar listings
* Orientation tables
* Examination board actions
* Professor listings
* Image preview components
* Administrative calendar actions

### Bootstrap 5 modal updates

Updated examination board appointment modals to use Bootstrap 5 data attributes:

* `data-toggle` → `data-bs-toggle`
* `data-target` → `data-bs-target`
* `data-dismiss` → `data-bs-dismiss`

### Appointment text modal improvements

Added styling to improve rendering of long markdown content inside appointment text modals:

* Prevent horizontal overflow
* Enable proper word wrapping
* Preserve formatting for preformatted text blocks